### PR TITLE
Allow users to specify gender in profile settings and display on profiles

### DIFF
--- a/drizzle/0015_secret_wallflower.sql
+++ b/drizzle/0015_secret_wallflower.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "profiles" ADD COLUMN "gender" text DEFAULT '' NOT NULL;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2329 @@
+{
+  "id": "0f237aa9-c6d8-4f78-811b-2a38afd95cce",
+  "prevId": "ffc2dac0-d1d9-4b00-a0d4-84d5dfc8f81e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachment_message_idx": {
+          "name": "attachment_message_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachment_cleanup_idx": {
+          "name": "attachment_cleanup_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachments_conversation_id_conversations_id_fk": {
+          "name": "attachments_conversation_id_conversations_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attachments_uploader_id_user_id_fk": {
+          "name": "attachments_uploader_id_user_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attachments_message_id_messages_id_fk": {
+          "name": "attachments_message_id_messages_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attachments_path_unique": {
+          "name": "attachments_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.avatars": {
+      "name": "avatars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "avatars_uploader_idx": {
+          "name": "avatars_uploader_idx",
+          "columns": [
+            {
+              "expression": "uploader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "avatars_active_user_idx": {
+          "name": "avatars_active_user_idx",
+          "columns": [
+            {
+              "expression": "uploader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"avatars\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "avatars_uploader_id_user_id_fk": {
+          "name": "avatars_uploader_id_user_id_fk",
+          "tableFrom": "avatars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "avatars_path_unique": {
+          "name": "avatars_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_users": {
+      "name": "blocked_users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blocked_target_idx": {
+          "name": "blocked_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocked_users_user_id_user_id_fk": {
+          "name": "blocked_users_user_id_user_id_fk",
+          "tableFrom": "blocked_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blocked_users_target_id_user_id_fk": {
+          "name": "blocked_users_target_id_user_id_fk",
+          "tableFrom": "blocked_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blocked_users_user_id_target_id_pk": {
+          "name": "blocked_users_user_id_target_id_pk",
+          "columns": [
+            "user_id",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_categories": {
+      "name": "channel_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "category_name_idx": {
+          "name": "category_name_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_categories_community_id_communities_id_fk": {
+          "name": "channel_categories_community_id_communities_id_fk",
+          "tableFrom": "channel_categories",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_icons": {
+      "name": "community_icons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_icons_uploader_idx": {
+          "name": "community_icons_uploader_idx",
+          "columns": [
+            {
+              "expression": "uploader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_icons_active_idx": {
+          "name": "community_icons_active_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"community_icons\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_icons_uploader_id_user_id_fk": {
+          "name": "community_icons_uploader_id_user_id_fk",
+          "tableFrom": "community_icons",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_icons_community_id_communities_id_fk": {
+          "name": "community_icons_community_id_communities_id_fk",
+          "tableFrom": "community_icons",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_icons_path_unique": {
+          "name": "community_icons_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_invites": {
+      "name": "community_invites",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "community_invite_community_idx": {
+          "name": "community_invite_community_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_invite_creator_idx": {
+          "name": "community_invite_creator_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_invites_community_id_communities_id_fk": {
+          "name": "community_invites_community_id_communities_id_fk",
+          "tableFrom": "community_invites",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_invites_created_by_user_id_fk": {
+          "name": "community_invites_created_by_user_id_fk",
+          "tableFrom": "community_invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_initiator_id": {
+          "name": "dm_initiator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dm_status": {
+          "name": "dm_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_channel_idx": {
+          "name": "community_channel_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_channel_name_idx": {
+          "name": "community_channel_name_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_dm_initiator_id_user_id_fk": {
+          "name": "conversations_dm_initiator_id_user_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "dm_initiator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_community_id_communities_id_fk": {
+          "name": "conversations_community_id_communities_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_category_id_channel_categories_id_fk": {
+          "name": "conversations_category_id_channel_categories_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "channel_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_events": {
+      "name": "app_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_user_idx": {
+          "name": "event_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_events_user_id_user_id_fk": {
+          "name": "app_events_user_id_user_id_fk",
+          "tableFrom": "app_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "friendship_recipient_idx": {
+          "name": "friendship_recipient_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_sender_id_user_id_fk": {
+          "name": "friendships_sender_id_user_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_recipient_id_user_id_fk": {
+          "name": "friendships_recipient_id_user_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_sender_id_recipient_id_pk": {
+          "name": "friendships_sender_id_recipient_id_pk",
+          "columns": [
+            "sender_id",
+            "recipient_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_limits": {
+      "name": "request_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_members": {
+      "name": "community_members",
+      "schema": "",
+      "columns": {
+        "community_id": {
+          "name": "community_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_user_idx": {
+          "name": "membership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_members_community_id_communities_id_fk": {
+          "name": "community_members_community_id_communities_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "communities",
+          "columnsFrom": [
+            "community_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_members_user_id_user_id_fk": {
+          "name": "community_members_user_id_user_id_fk",
+          "tableFrom": "community_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_members_community_id_user_id_pk": {
+          "name": "community_members_community_id_user_id_pk",
+          "columns": [
+            "community_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "message_conversation_cursor_idx": {
+          "name": "message_conversation_cursor_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_parent_idx": {
+          "name": "message_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_search_idx": {
+          "name": "message_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"content\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "message_unread_idx": {
+          "name": "message_unread_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_author_id_user_id_fk": {
+          "name": "messages_author_id_user_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_idx": {
+          "name": "notification_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_user_id_fk": {
+          "name": "notifications_actor_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_message_id_messages_id_fk": {
+          "name": "notifications_message_id_messages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_members": {
+      "name": "conversation_members",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "participant_user_idx": {
+          "name": "participant_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_members_conversation_id_conversations_id_fk": {
+          "name": "conversation_members_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_members",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_members_user_id_user_id_fk": {
+          "name": "conversation_members_user_id_user_id_fk",
+          "tableFrom": "conversation_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_members_conversation_id_user_id_pk": {
+          "name": "conversation_members_conversation_id_user_id_pk",
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'purple'"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "activity": {
+          "name": "activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_user_id_fk": {
+          "name": "profiles_user_id_user_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_handle_unique": {
+          "name": "profiles_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limit_key_unique": {
+          "name": "rate_limit_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_reactions": {
+      "name": "message_reactions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_user_id_fk": {
+          "name": "message_reactions_user_id_user_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_reactions_message_id_user_id_emoji_pk": {
+          "name": "message_reactions_message_id_user_id_emoji_pk",
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_read_states": {
+      "name": "conversation_read_states",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_read_states_user_id_user_id_fk": {
+          "name": "conversation_read_states_user_id_user_id_fk",
+          "tableFrom": "conversation_read_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_read_states_conversation_id_conversations_id_fk": {
+          "name": "conversation_read_states_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_read_states",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_read_states_user_id_conversation_id_pk": {
+          "name": "conversation_read_states_user_id_conversation_id_pk",
+          "columns": [
+            "user_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_messages": {
+      "name": "saved_messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_messages_message_id_messages_id_fk": {
+          "name": "saved_messages_message_id_messages_id_fk",
+          "tableFrom": "saved_messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_messages_user_id_user_id_fk": {
+          "name": "saved_messages_user_id_user_id_fk",
+          "tableFrom": "saved_messages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "saved_messages_message_id_user_id_pk": {
+          "name": "saved_messages_message_id_user_id_pk",
+          "columns": [
+            "message_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1788954644346,
       "tag": "0014_serious_matthew_murdock",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1788970861540,
+      "tag": "0015_secret_wallflower",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/app/app-dialogs.tsx
+++ b/src/components/app/app-dialogs.tsx
@@ -879,7 +879,7 @@ function Profile({ personId }: { personId: string }) {
       </div>
       <div
         data-ui="a-profile-details"
-        className="pt-0 pb-px px-2 *:data-[ui~=a-avatar]:-mt-7.75 *:data-[ui~=a-avatar]:border-[5px] *:data-[ui~=a-avatar]:border-solid *:data-[ui~=a-avatar]:border-(--a-bg) *:data-[ui~=a-avatar]:rounded-[26px] *:data-[ui~=a-avatar]:mb-2.5 [&_h3]:text-[25px] [&_h3]:mb-1.25 [&_h3]:tracking-[-0.8px] [&>span:not([data-ui~=a-avatar])]:text-(--a-faint) [&>span:not([data-ui~=a-avatar])]:text-[12px] **:data-[ui~=a-role-tag]:ml-2 [&>p]:text-[14px] [&>p]:leading-[1.8] [&>p]:mt-4.75 [&>p]:text-(--a-muted) [&>p]:whitespace-pre-wrap [&>p]:wrap-anywhere [&>select]:w-full [&>select]:mt-2 [&>select]:mb-4.5 [&>select]:text-[12px] max-[480px]:[&_h3]:text-[25px] max-[480px]:[&>p]:text-[13px]"
+        className="pt-0 pb-px px-2 *:data-[ui~=a-avatar]:-mt-7.75 *:data-[ui~=a-avatar]:border-[5px] *:data-[ui~=a-avatar]:border-solid *:data-[ui~=a-avatar]:border-(--a-bg) *:data-[ui~=a-avatar]:rounded-[26px] *:data-[ui~=a-avatar]:mb-2.5 [&_h3]:text-[25px] [&_h3]:mb-1.25 [&_h3]:tracking-[-0.8px] [&>span:not([data-ui~=a-avatar])]:text-(--a-faint) [&>span:not([data-ui~=a-avatar])]:text-[12px] **:data-[ui~=a-role-tag]:ml-2 **:data-[ui~=a-gender-tag]:ml-1.5 [&>p]:text-[14px] [&>p]:leading-[1.8] [&>p]:mt-4.75 [&>p]:text-(--a-muted) [&>p]:whitespace-pre-wrap [&>p]:wrap-anywhere [&>select]:w-full [&>select]:mt-2 [&>select]:mb-4.5 [&>select]:text-[12px] max-[480px]:[&_h3]:text-[25px] max-[480px]:[&>p]:text-[13px]"
       >
         <PersonAvatar person={person} large presence />
         <h3>{person.name}</h3>
@@ -891,6 +891,14 @@ function Profile({ personId }: { personId: string }) {
           >
             {person.role}
           </span>
+          {person.gender && (
+            <span
+              data-ui="a-gender-tag"
+              className="inline-block py-0.75 px-1.75 border border-solid border-(--a-border) rounded-sm bg-(--a-soft) text-[9px] text-(--a-muted)"
+            >
+              {person.gender}
+            </span>
+          )}
         </span>
         <p className="[&_a]:text-(--a-green) [&_a]:underline [&_a]:underline-offset-3">
           <AutoLinkText

--- a/src/components/app/mention.tsx
+++ b/src/components/app/mention.tsx
@@ -97,6 +97,14 @@ export function Mention({ target }: { target: MentionTarget }) {
                     >
                       {person.role}
                     </span>
+                    {person.gender && (
+                      <span
+                        data-ui="a-gender-tag"
+                        className="inline-block py-0.75 px-1.75 border border-solid border-(--a-border) rounded-sm bg-(--a-soft) text-[9px] text-(--a-muted)"
+                      >
+                        {person.gender}
+                      </span>
+                    )}
                   </div>
                   <p className="whitespace-pre-wrap [&_a]:text-(--a-green) [&_a]:underline [&_a]:underline-offset-3">
                     <AutoLinkText

--- a/src/components/app/mention.tsx
+++ b/src/components/app/mention.tsx
@@ -100,7 +100,7 @@ export function Mention({ target }: { target: MentionTarget }) {
                     {person.gender && (
                       <span
                         data-ui="a-gender-tag"
-                        className="inline-block py-0.75 px-1.75 border border-solid border-(--a-border) rounded-sm bg-(--a-soft) text-[9px] text-(--a-muted)"
+                        className="inline-block min-w-0 max-w-full wrap-anywhere py-0.75 px-1.75 border border-solid border-(--a-border) rounded-sm bg-(--a-soft) text-[9px] text-(--a-muted)"
                       >
                         {person.gender}
                       </span>

--- a/src/components/app/settings-page.tsx
+++ b/src/components/app/settings-page.tsx
@@ -2,7 +2,7 @@ import { AvatarUpload } from "./avatar-upload";
 import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useApp } from "../../lib/app-state";
-import type { Preferences } from "../../types/app";
+import type { Gender, Preferences } from "../../types/app";
 import { AppIcon, PageHeading, PersonAvatar, Toggle } from "./primitives";
 import type { IconName } from "./primitives";
 import { authClient } from "../../lib/auth-client";
@@ -28,7 +28,7 @@ export function SettingsPage({ section }: { section: string }) {
   const [name, setName] = useState(state.profile.name);
   const [handle, setHandle] = useState(state.profile.handle);
   const [bio, setBio] = useState(state.profile.bio);
-  const [gender, setGender] = useState(state.profile.gender ?? "");
+  const [gender, setGender] = useState<Gender>(state.profile.gender ?? "");
   const [activity, setActivity] = useState(state.profile.activity);
   const [color, setColor] = useState(state.profile.color);
   const [error, setError] = useState("");
@@ -176,7 +176,7 @@ export function SettingsPage({ section }: { section: string }) {
                       name: name.trim(),
                       handle,
                       bio: bio.trim(),
-                      gender: gender.trim(),
+                      gender,
                       activity: activity.trim(),
                       color,
                     },
@@ -221,12 +221,16 @@ export function SettingsPage({ section }: { section: string }) {
                   </label>
                   <label>
                     Gender
-                    <input
+                    <select
                       value={gender}
-                      maxLength={40}
-                      onChange={(event) => setGender(event.target.value)}
-                      placeholder="e.g. Woman, Man, Non-binary"
-                    />
+                      onChange={(event) =>
+                        setGender(event.target.value as Gender)
+                      }
+                    >
+                      <option value="">Prefer not to say</option>
+                      <option value="he/him">he/him</option>
+                      <option value="she/her">she/her</option>
+                    </select>
                   </label>
                   <label>
                     A little about you

--- a/src/components/app/settings-page.tsx
+++ b/src/components/app/settings-page.tsx
@@ -28,6 +28,7 @@ export function SettingsPage({ section }: { section: string }) {
   const [name, setName] = useState(state.profile.name);
   const [handle, setHandle] = useState(state.profile.handle);
   const [bio, setBio] = useState(state.profile.bio);
+  const [gender, setGender] = useState(state.profile.gender ?? "");
   const [activity, setActivity] = useState(state.profile.activity);
   const [color, setColor] = useState(state.profile.color);
   const [error, setError] = useState("");
@@ -35,12 +36,14 @@ export function SettingsPage({ section }: { section: string }) {
     setName(state.profile.name);
     setHandle(state.profile.handle);
     setBio(state.profile.bio);
+    setGender(state.profile.gender ?? "");
     setActivity(state.profile.activity);
     setColor(state.profile.color);
   }, [
     state.profile.name,
     state.profile.handle,
     state.profile.bio,
+    state.profile.gender,
     state.profile.activity,
     state.profile.color,
   ]);
@@ -56,12 +59,14 @@ export function SettingsPage({ section }: { section: string }) {
     ...state.profile,
     name: name || state.profile.name,
     bio,
+    gender,
     color,
   };
   const dirty =
     name !== state.profile.name ||
     handle !== state.profile.handle ||
     bio !== state.profile.bio ||
+    gender !== (state.profile.gender ?? "") ||
     activity !== state.profile.activity ||
     color !== state.profile.color;
   function exportData() {
@@ -171,6 +176,7 @@ export function SettingsPage({ section }: { section: string }) {
                       name: name.trim(),
                       handle,
                       bio: bio.trim(),
+                      gender: gender.trim(),
                       activity: activity.trim(),
                       color,
                     },
@@ -212,6 +218,15 @@ export function SettingsPage({ section }: { section: string }) {
                         required
                       />
                     </div>
+                  </label>
+                  <label>
+                    Gender
+                    <input
+                      value={gender}
+                      maxLength={40}
+                      onChange={(event) => setGender(event.target.value)}
+                      placeholder="e.g. Woman, Man, Non-binary"
+                    />
                   </label>
                   <label>
                     A little about you
@@ -308,7 +323,17 @@ export function SettingsPage({ section }: { section: string }) {
                     <section>
                       <PersonAvatar person={preview} large presence />
                       <h3>{name || "Your name"}</h3>
-                      <span>@{handle || "yourname"}</span>
+                      <span className="flex items-center gap-1.5 flex-wrap">
+                        <span>@{handle || "yourname"}</span>
+                        {gender.trim() && (
+                          <span
+                            data-ui="a-gender-tag"
+                            className="inline-block py-0.5 px-1.75 border border-solid border-(--a-border) rounded-sm bg-(--a-soft) text-[9px] text-(--a-muted)"
+                          >
+                            {gender.trim()}
+                          </span>
+                        )}
+                      </span>
                       <p>{bio || "Sometimes a hello says enough."}</p>
                       <small>
                         <i

--- a/src/lib/app-state.tsx
+++ b/src/lib/app-state.tsx
@@ -72,6 +72,7 @@ const empty: AppState = {
     status: "offline",
     bio: "",
     activity: "",
+    gender: "",
     role: "Member",
   },
   people: [],
@@ -893,6 +894,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
           status: "offline",
           bio: "",
           activity: "",
+          gender: "",
           role: "Member",
         });
   }

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -85,6 +85,7 @@ export const actionSchema = z.discriminatedUnion("type", [
     color: z.enum(["peach", "green", "purple", "yellow", "blue"]),
     bio: z.string().max(500),
     activity: z.string().max(140),
+    gender: z.string().trim().max(40).optional().default(""),
     status: z.enum(["online", "away", "offline"]),
   }),
   z.object({

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -85,7 +85,7 @@ export const actionSchema = z.discriminatedUnion("type", [
     color: z.enum(["peach", "green", "purple", "yellow", "blue"]),
     bio: z.string().max(500),
     activity: z.string().max(140),
-    gender: z.string().trim().max(40).optional().default(""),
+    gender: z.enum(["", "he/him", "she/her"]).optional().default(""),
     status: z.enum(["online", "away", "offline"]),
   }),
   z.object({

--- a/src/lib/people.ts
+++ b/src/lib/people.ts
@@ -1,4 +1,8 @@
-import type { Person } from "../types/app";
+import type { Gender, Person } from "../types/app";
+
+export function normalizeGender(gender: unknown): Gender {
+  return gender === "he/him" || gender === "she/her" ? gender : "";
+}
 
 export function personName(person?: Person) {
   return person?.name.split(" ")[0] ?? "Someone";

--- a/src/lib/state-actions.ts
+++ b/src/lib/state-actions.ts
@@ -22,6 +22,7 @@ export function stateActions(previous: AppState, next: AppState): Action[] {
       color: color as "peach",
       bio,
       activity,
+      gender: next.profile.gender ?? "",
       status,
     });
   }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -91,6 +91,7 @@ export const profiles = pgTable("profiles", {
   color: text("color").notNull().default("purple"),
   bio: text("bio").notNull().default(""),
   activity: text("activity").notNull().default(""),
+  gender: text("gender").notNull().default(""),
   status: text("status", { enum: ["online", "away", "offline"] })
     .notNull()
     .default("online"),

--- a/src/server/directory.ts
+++ b/src/server/directory.ts
@@ -1,6 +1,11 @@
 import { sql, type SQL } from "drizzle-orm";
 import type { Database } from "./db";
 import type { Community, Person } from "../types/app";
+import { normalizeGender } from "../lib/people";
+
+function normalizePerson(person: Person): Person {
+  return { ...person, gender: normalizeGender(person.gender) };
+}
 
 export function personJson(userId: string) {
   return sql`jsonb_build_object('id', case when p.user_id = ${userId} then 'you' else p.user_id end,
@@ -14,7 +19,7 @@ export async function peopleFor(db: Database, userId: string, ids: string[]) {
   const result = await db.execute<{ person: Person }>(
     sql`select ${personJson(userId)} as person from profiles p join "user" u on u.id = p.user_id where p.user_id = any(${sql.param(ids)}::text[])`,
   );
-  return result.rows.map((row) => row.person);
+  return result.rows.map((row) => normalizePerson(row.person));
 }
 export async function directory(
   db: Database,
@@ -38,7 +43,9 @@ export async function directory(
         and not exists(select 1 from blocked_users b where b.user_id = ${userId} and b.target_id = p.user_id)
       order by p.handle, p.user_id limit 51 offset ${input.offset}`);
     return {
-      people: result.rows.slice(0, 50).map((row) => row.person),
+      people: result.rows.slice(0, 50).map((row) =>
+        normalizePerson(row.person),
+      ),
       hasMore: result.rows.length > 50,
     };
   }

--- a/src/server/directory.ts
+++ b/src/server/directory.ts
@@ -4,7 +4,7 @@ import type { Community, Person } from "../types/app";
 
 export function personJson(userId: string) {
   return sql`jsonb_build_object('id', case when p.user_id = ${userId} then 'you' else p.user_id end,
-    'name', u.name, 'handle', case when p.handle ~ '^user_[a-z0-9]{19}$' then '' else coalesce(p.handle, '') end, 'color', p.color, 'bio', p.bio,
+    'name', u.name, 'handle', case when p.handle ~ '^user_[a-z0-9]{19}$' then '' else coalesce(p.handle, '') end, 'color', p.color, 'bio', p.bio, 'gender', coalesce(p.gender, ''),
     'activity', case when (p.preferences->>'activity')::boolean then p.activity else '' end,
     'status', case when p.last_seen_at < now() - interval '90 seconds' then 'offline' else p.status end,
     'role', 'Member', 'avatarUrl', (select '/api/avatars/' || a.id from avatars a where a.uploader_id = p.user_id and a.status = 'active'))`;

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -227,6 +227,7 @@ export async function snapshot(
     avatarUrl: p.avatarId ? `/api/avatars/${p.avatarId}` : undefined,
     handle: chosenUsername(p.profile.handle),
     bio: p.profile.bio,
+    gender: p.profile.gender ?? "",
     color: p.profile.color,
     activity: p.profile.preferences.activity ? p.profile.activity : "",
     status:

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -22,6 +22,7 @@ import {
   requireConversation,
 } from "./access";
 import type { Community, AppState, Message, Person } from "../types/app";
+import { normalizeGender } from "../lib/people";
 import { HttpError } from "./http";
 import { hydrate, rowJson } from "./sql-json";
 import { chosenUsername } from "../lib/usernames";
@@ -227,10 +228,7 @@ export async function snapshot(
     avatarUrl: p.avatarId ? `/api/avatars/${p.avatarId}` : undefined,
     handle: chosenUsername(p.profile.handle),
     bio: p.profile.bio,
-    gender:
-      p.profile.gender === "he/him" || p.profile.gender === "she/her"
-        ? p.profile.gender
-        : "",
+    gender: normalizeGender(p.profile.gender),
     color: p.profile.color,
     activity: p.profile.preferences.activity ? p.profile.activity : "",
     status:

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -227,7 +227,10 @@ export async function snapshot(
     avatarUrl: p.avatarId ? `/api/avatars/${p.avatarId}` : undefined,
     handle: chosenUsername(p.profile.handle),
     bio: p.profile.bio,
-    gender: p.profile.gender ?? "",
+    gender:
+      p.profile.gender === "he/him" || p.profile.gender === "she/her"
+        ? p.profile.gender
+        : "",
     color: p.profile.color,
     activity: p.profile.preferences.activity ? p.profile.activity : "",
     status:

--- a/src/server/realtime/data.ts
+++ b/src/server/realtime/data.ts
@@ -12,6 +12,7 @@ import { HttpError } from "../http.ts";
 import { sendMessage } from "../send-message.ts";
 import type { MessageUpdate, Room } from "../../lib/realtime-protocol.ts";
 import type { Person, Message, DirectConversation } from "../../types/app.ts";
+import { normalizeGender } from "../../lib/people.ts";
 
 export type Identity = {
   userId: string;
@@ -100,7 +101,14 @@ export async function liveMessages(
       ...(row.dmConversation
         ? { dmConversation: { ...row.dmConversation, unread: row.unread } }
         : {}),
-      ...(row.person ? { person: row.person } : {}),
+      ...(row.person
+        ? {
+            person: {
+              ...row.person,
+              gender: normalizeGender(row.person.gender),
+            },
+          }
+        : {}),
     };
     return { userId: row.userId, frame };
   });

--- a/src/server/realtime/data.ts
+++ b/src/server/realtime/data.ts
@@ -76,7 +76,7 @@ export async function liveMessages(
       'attachments', coalesce((select json_agg(json_build_object('id', a.id, 'name', a.original_name, 'contentType', a.content_type, 'byteSize', a.byte_size, 'url', '/api/attachments/' || a.id)) from attachments a where a.message_id = m.id and a.status = 'ready'), '[]'::json)
     ) end as message,
     case when p.user_id is null then null else json_build_object('id', case when p.user_id = ${userId} then 'you' else p.user_id end,
-      'name', u.name, 'handle', case when p.handle ~ '^user_[a-z0-9]{19}$' then '' else coalesce(p.handle, '') end, 'color', p.color, 'bio', p.bio, 'activity', case when (p.preferences->>'activity')::boolean then p.activity else '' end,
+      'name', u.name, 'handle', case when p.handle ~ '^user_[a-z0-9]{19}$' then '' else coalesce(p.handle, '') end, 'color', p.color, 'bio', p.bio, 'gender', coalesce(p.gender, ''), 'activity', case when (p.preferences->>'activity')::boolean then p.activity else '' end,
       'status', case when p.last_seen_at < now() - interval '90 seconds' then 'offline' else p.status end,
       'role', 'Member', 'avatarUrl', (select '/api/avatars/' || a.id from avatars a where a.uploader_id = p.user_id and a.status = 'active' limit 1)) end as person,
     (select count(*)::int from messages unread where unread.conversation_id = ${s.conversations.id}

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -8,6 +8,7 @@ export type Person = {
   status: Presence;
   bio: string;
   activity: string;
+  gender?: string;
   role: "Owner" | "Admin" | "Moderator" | "Member";
 };
 export type Channel = {

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,4 +1,5 @@
 export type Presence = "online" | "away" | "offline";
+export type Gender = "he/him" | "she/her" | "";
 export type Person = {
   avatarUrl?: string;
   id: string;
@@ -8,7 +9,7 @@ export type Person = {
   status: Presence;
   bio: string;
   activity: string;
-  gender?: string;
+  gender?: Gender;
   role: "Owner" | "Admin" | "Moderator" | "Member";
 };
 export type Channel = {

--- a/tests/profile-gender.test.ts
+++ b/tests/profile-gender.test.ts
@@ -1,0 +1,106 @@
+import { after, before, test } from "node:test";
+import assert from "node:assert/strict";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import * as schema from "../src/server/db/schema";
+import type { Database } from "../src/server/db";
+import { mutate } from "../src/server/actions";
+import { ensureProfile } from "../src/server/access";
+import { snapshot } from "../src/server/queries";
+import { actionSchema } from "../src/lib/contracts";
+import { stateActions } from "../src/lib/state-actions";
+import type { AppState } from "../src/lib/app-state";
+
+const engine = new PGlite();
+const database = drizzle(engine, { schema });
+const db = database as unknown as Database;
+const userA = { id: "user_a", name: "Alice" };
+const userB = { id: "user_b", name: "Bob" };
+
+before(async () => {
+  await migrate(database, { migrationsFolder: "./drizzle" });
+  for (const viewer of [userA, userB]) {
+    await db
+      .insert(schema.user)
+      .values({ ...viewer, email: `${viewer.id}@example.test` });
+    await ensureProfile(db, viewer);
+  }
+  await db.insert(schema.friendships).values({
+    senderId: userA.id,
+    recipientId: userB.id,
+    status: "accepted",
+  });
+});
+
+after(async () => {
+  await engine.close();
+});
+
+async function runAction(userId: string, input: unknown) {
+  return db.transaction((tx) =>
+    mutate(tx as unknown as Database, userId, actionSchema.parse(input)),
+  );
+}
+
+test("profile gender can be saved, updated, and queried in snapshots", async () => {
+  const profileAction = {
+    type: "profile" as const,
+    name: "Alice",
+    handle: "alice_wonder",
+    color: "peach" as const,
+    bio: "Curiouser and curiouser",
+    gender: "Woman",
+    activity: "Exploring",
+    status: "online" as const,
+  };
+
+  // 1. Action schema parses valid gender
+  const parsed = actionSchema.parse(profileAction);
+  assert.equal(parsed.gender, "Woman");
+
+  // 2. Mutate saves gender to database
+  await runAction(userA.id, profileAction);
+
+  // 3. User snapshot returns gender for own profile
+  const ownSnapshot = await snapshot(db, userA);
+  assert.equal(ownSnapshot.profile.gender, "Woman");
+
+  // 4. Other user snapshot returns gender in people list
+  const otherSnapshot = await snapshot(db, userB);
+  const aliceInPeople = otherSnapshot.people.find((p) => p.id === userA.id);
+  assert.ok(aliceInPeople);
+  assert.equal(aliceInPeople.gender, "Woman");
+
+  // 5. Gender field trims whitespace
+  const trimmedAction = {
+    ...profileAction,
+    gender: "  Non-binary  ",
+  };
+  await runAction(userA.id, trimmedAction);
+  const updatedSnapshot = await snapshot(db, userA);
+  assert.equal(updatedSnapshot.profile.gender, "Non-binary");
+
+  // 6. Max length validation (<= 40 chars succeeds, > 40 chars fails)
+  assert.equal(
+    actionSchema.safeParse({ ...profileAction, gender: "a".repeat(40) }).success,
+    true,
+  );
+  assert.equal(
+    actionSchema.safeParse({ ...profileAction, gender: "a".repeat(41) }).success,
+    false,
+  );
+
+  // 7. State actions generates profile action including gender
+  const mockState: AppState = {
+    ...ownSnapshot,
+    profile: {
+      ...ownSnapshot.profile,
+      gender: "She/Her",
+    },
+  };
+  const diffs = stateActions(ownSnapshot, mockState);
+  assert.equal(diffs.length, 1);
+  assert.equal(diffs[0].type, "profile");
+  assert.equal((diffs[0] as typeof profileAction).gender, "She/Her");
+});

--- a/tests/profile-gender.test.ts
+++ b/tests/profile-gender.test.ts
@@ -50,57 +50,70 @@ test("profile gender can be saved, updated, and queried in snapshots", async () 
     handle: "alice_wonder",
     color: "peach" as const,
     bio: "Curiouser and curiouser",
-    gender: "Woman",
+    gender: "she/her" as const,
     activity: "Exploring",
     status: "online" as const,
   };
 
   // 1. Action schema parses valid gender
   const parsed = actionSchema.parse(profileAction);
-  assert.equal(parsed.gender, "Woman");
+  assert.equal(parsed.gender, "she/her");
 
   // 2. Mutate saves gender to database
   await runAction(userA.id, profileAction);
 
   // 3. User snapshot returns gender for own profile
   const ownSnapshot = await snapshot(db, userA);
-  assert.equal(ownSnapshot.profile.gender, "Woman");
+  assert.equal(ownSnapshot.profile.gender, "she/her");
 
   // 4. Other user snapshot returns gender in people list
   const otherSnapshot = await snapshot(db, userB);
   const aliceInPeople = otherSnapshot.people.find((p) => p.id === userA.id);
   assert.ok(aliceInPeople);
-  assert.equal(aliceInPeople.gender, "Woman");
+  assert.equal(aliceInPeople.gender, "she/her");
 
-  // 5. Gender field trims whitespace
-  const trimmedAction = {
-    ...profileAction,
-    gender: "  Non-binary  ",
-  };
-  await runAction(userA.id, trimmedAction);
+  // 5. Gender can be updated to he/him
+  await runAction(userA.id, { ...profileAction, gender: "he/him" });
   const updatedSnapshot = await snapshot(db, userA);
-  assert.equal(updatedSnapshot.profile.gender, "Non-binary");
+  assert.equal(updatedSnapshot.profile.gender, "he/him");
 
-  // 6. Max length validation (<= 40 chars succeeds, > 40 chars fails)
+  // 6. Gender can be updated to empty string (prefer not to say)
+  await runAction(userA.id, { ...profileAction, gender: "" });
+  const clearedSnapshot = await snapshot(db, userA);
+  assert.equal(clearedSnapshot.profile.gender, "");
+
+  // 7. Rejects invalid gender values
   assert.equal(
-    actionSchema.safeParse({ ...profileAction, gender: "a".repeat(40) }).success,
+    actionSchema.safeParse({ ...profileAction, gender: "he/him" }).success,
     true,
   );
   assert.equal(
-    actionSchema.safeParse({ ...profileAction, gender: "a".repeat(41) }).success,
+    actionSchema.safeParse({ ...profileAction, gender: "she/her" }).success,
+    true,
+  );
+  assert.equal(
+    actionSchema.safeParse({ ...profileAction, gender: "" }).success,
+    true,
+  );
+  assert.equal(
+    actionSchema.safeParse({ ...profileAction, gender: "other" }).success,
+    false,
+  );
+  assert.equal(
+    actionSchema.safeParse({ ...profileAction, gender: "Woman" }).success,
     false,
   );
 
-  // 7. State actions generates profile action including gender
+  // 8. State actions generates profile action including gender
   const mockState: AppState = {
     ...ownSnapshot,
     profile: {
       ...ownSnapshot.profile,
-      gender: "She/Her",
+      gender: "he/him",
     },
   };
   const diffs = stateActions(ownSnapshot, mockState);
   assert.equal(diffs.length, 1);
   assert.equal(diffs[0].type, "profile");
-  assert.equal((diffs[0] as typeof profileAction).gender, "She/Her");
+  assert.equal((diffs[0] as typeof profileAction).gender, "he/him");
 });

--- a/tests/profile-gender.test.ts
+++ b/tests/profile-gender.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
+import { eq } from "drizzle-orm";
 import * as schema from "../src/server/db/schema";
 import type { Database } from "../src/server/db";
 import { mutate } from "../src/server/actions";
@@ -11,6 +12,7 @@ import { snapshot } from "../src/server/queries";
 import { actionSchema } from "../src/lib/contracts";
 import { stateActions } from "../src/lib/state-actions";
 import type { AppState } from "../src/lib/app-state";
+import { peopleFor } from "../src/server/directory";
 
 const engine = new PGlite();
 const database = drizzle(engine, { schema });
@@ -116,4 +118,14 @@ test("profile gender can be saved, updated, and queried in snapshots", async () 
   assert.equal(diffs.length, 1);
   assert.equal(diffs[0].type, "profile");
   assert.equal((diffs[0] as typeof profileAction).gender, "he/him");
+
+  // 9. Legacy values are normalized in snapshot and directory projections
+  await db
+    .update(schema.profiles)
+    .set({ gender: "legacy-value" })
+    .where(eq(schema.profiles.userId, userA.id));
+  const legacySnapshot = await snapshot(db, userA);
+  assert.equal(legacySnapshot.profile.gender, "");
+  const [legacyPerson] = await peopleFor(db, userB.id, [userA.id]);
+  assert.equal(legacyPerson.gender, "");
 });


### PR DESCRIPTION
### Summary
This PR allows users to specify their gender in their profile settings via a select dropdown with options for `he/him`, `she/her`, and `Prefer not to say`. It persists this in the database and realtime models, and renders it as a styled tag across profile views.

### Changes
- **Database Schema & Migrations**:
  - Added `gender` text column (default `""`, not null) to `profiles` table in `src/server/db/schema.ts`.
  - Added Drizzle migration `drizzle/0015_secret_wallflower.sql` and updated Drizzle journal/snapshots.
- **Contracts & Backend**:
  - Restricted `gender` field in `actionSchema` (`src/lib/contracts.ts`) to `z.enum(["", "he/him", "she/her"]).optional().default("")`.
  - Added `Gender = "he/him" | "she/her" | ""` and `gender?: Gender` to `Person` type in `src/types/app.ts`.
  - Included `gender` projection in snapshot queries (`src/server/queries.ts`), directory listings (`src/server/directory.ts`), and realtime data feeds (`src/server/realtime/data.ts`).
  - Added `gender` field to `stateActions` diff generator in `src/lib/state-actions.ts`.
- **UI Components**:
  - `src/components/app/settings-page.tsx`: Replaced text input with a fixed `<select>` dropdown featuring:
    - *Prefer not to say* (`""`)
    - *he/him*
    - *she/her*
    - Displays `data-ui="a-gender-tag"` next to the handle in the profile preview card when set.
  - `src/components/app/app-dialogs.tsx`: Rendered `a-gender-tag` in the user profile modal popup next to the role tag.
  - `src/components/app/mention.tsx`: Rendered `a-gender-tag` in the mention hover preview card.
- **Tests**:
  - Added and updated `tests/profile-gender.test.ts` testing schema validation, mutation saving, snapshot retrieval for own/other profiles, value rejection, and state action generation.

### Verification
- `pnpm run typecheck` (`tsc --noEmit`) passed with 0 errors.
- `pnpm test` (99 tests) passed completely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gender pronoun options to profile settings.
  * Saved pronoun selections to user profiles and displayed them as profile tags.
  * Pronoun tags now appear in profile previews, mentions, directories, and other profile-related views.
  * Added validation to accept supported pronoun options and safely handle unavailable or invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->