### PR TITLE
Add community bans with invite and rejoin blocking

### DIFF
--- a/drizzle/0015_community_bans.sql
+++ b/drizzle/0015_community_bans.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "community_bans" (
+	"community_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"banned_by" text,
+	"reason" text DEFAULT '' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "community_bans_community_id_user_id_pk" PRIMARY KEY("community_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "community_bans" ADD CONSTRAINT "community_bans_community_id_communities_id_fk" FOREIGN KEY ("community_id") REFERENCES "public"."communities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "community_bans" ADD CONSTRAINT "community_bans_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "community_bans" ADD CONSTRAINT "community_bans_banned_by_user_id_fk" FOREIGN KEY ("banned_by") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "community_ban_user_idx" ON "community_bans" USING btree ("user_id");

--- a/drizzle/0016_community_ban_roles.sql
+++ b/drizzle/0016_community_ban_roles.sql
@@ -1,1 +1,2 @@
-ALTER TABLE "community_bans" ADD COLUMN "role" text DEFAULT 'Member' NOT NULL;
+ALTER TABLE "community_bans" ADD COLUMN "role" text DEFAULT 'Admin' NOT NULL;--> statement-breakpoint
+ALTER TABLE "community_bans" ALTER COLUMN "role" SET DEFAULT 'Member';

--- a/drizzle/0016_community_ban_roles.sql
+++ b/drizzle/0016_community_ban_roles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "community_bans" ADD COLUMN "role" text DEFAULT 'Member' NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1788954644346,
       "tag": "0014_serious_matthew_murdock",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1788960000000,
+      "tag": "0015_community_bans",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1788960000000,
       "tag": "0015_community_bans",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1788963600000,
+      "tag": "0016_community_ban_roles",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/app/community-settings.tsx
+++ b/src/components/app/community-settings.tsx
@@ -582,8 +582,16 @@ export function CommunitySettings({ communityId }: { communityId: string }) {
                 const banned =
                   bannedId === "you"
                     ? state.profile
-                    : state.people.find((p) => p.id === bannedId);
-                if (!banned) return null;
+                    : (state.people.find((p) => p.id === bannedId) ?? {
+                        id: bannedId,
+                        name: "Banned member",
+                        handle: "",
+                        color: "peach",
+                        status: "offline",
+                        bio: "",
+                        activity: "",
+                        role: "Member",
+                      } as const);
                 return (
                   <div
                     data-ui="a-community-member-row"

--- a/src/components/app/community-settings.tsx
+++ b/src/components/app/community-settings.tsx
@@ -538,6 +538,27 @@ export function CommunitySettings({ communityId }: { communityId: string }) {
                         })
                       }
                     />
+                    <IconButton
+                      name="shield"
+                      label={`Ban ${person.name}`}
+                      onClick={() =>
+                        setModal({
+                          type: "confirm",
+                          title: `Ban ${person.name}?`,
+                          description:
+                            "They will lose access and can't rejoin, even with an invite link. Use Remove for a temporary goodbye instead.",
+                          label: "Ban member",
+                          managedCommunityId: communityId,
+                          action: () => {
+                            void command({
+                              type: "member.ban",
+                              communityId,
+                              userId: person.id,
+                            });
+                          },
+                        })
+                      }
+                    />
                   </>
                 )}
                 <IconButton
@@ -549,6 +570,49 @@ export function CommunitySettings({ communityId }: { communityId: string }) {
                 />
               </div>
             ))}
+          {(community.bannedIds?.length ?? 0) > 0 && (
+            <section aria-label="Banned members" className="mt-8">
+              <div className="mb-2">
+                <h2 className="text-[21px]">Banned.</h2>
+                <p className="text-[12px] text-(--a-muted) mt-1.75">
+                  These people can&apos;t rejoin, even with an invite link.
+                </p>
+              </div>
+              {(community.bannedIds ?? []).map((bannedId) => {
+                const banned =
+                  bannedId === "you"
+                    ? state.profile
+                    : state.people.find((p) => p.id === bannedId);
+                if (!banned) return null;
+                return (
+                  <div
+                    data-ui="a-community-member-row"
+                    className="flex items-center gap-3.25 py-4.5 px-1.25 [border-bottom-width:1px] [border-bottom-style:solid] border-b-(--a-border) [&>span:nth-child(2)]:flex-1 [&_strong]:block [&_strong]:text-[13px] [&_strong]:font-[550] [&_small]:block [&_small]:text-[11px] [&_small]:text-(--a-faint) [&_small]:mt-1.25"
+                    key={bannedId}
+                  >
+                    <PersonAvatar person={banned} />
+                    <span>
+                      <strong>{banned.name}</strong>
+                      {banned.handle && <small>@{banned.handle}</small>}
+                    </span>
+                    <button
+                      data-ui="a-button secondary"
+                      className="inline-flex justify-center items-center gap-2.25 min-h-10 py-2.5 px-4 rounded-md leading-[1.4] whitespace-nowrap border! border-solid! border-transparent! font-[550]! text-[12px]! data-[ui~=secondary]:bg-(--a-surface) data-[ui~=secondary]:text-(--a-text) data-[ui~=secondary]:border-(--a-border)!"
+                      onClick={() =>
+                        void command({
+                          type: "member.unban",
+                          communityId,
+                          userId: banned.id,
+                        })
+                      }
+                    >
+                      Unban
+                    </button>
+                  </div>
+                );
+              })}
+            </section>
+          )}
         </>
       )}
     </div>

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -122,6 +122,13 @@ export const actionSchema = z.discriminatedUnion("type", [
   }),
   z.object({ type: z.literal("member.remove"), communityId: id, userId: id }),
   z.object({
+    type: z.literal("member.ban"),
+    communityId: id,
+    userId: id,
+    reason: z.string().trim().max(500).optional(),
+  }),
+  z.object({ type: z.literal("member.unban"), communityId: id, userId: id }),
+  z.object({
     type: z.literal("channel.access"),
     conversation: key,
     userId: id,

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -281,37 +281,35 @@ export async function mutate(db: Database, userId: string, action: Action) {
     case "member.unban": {
       const ownRole = await requireManager(db, userId, action.communityId);
       const targetRole = await roleFor(db, action.userId, action.communityId);
+      // Bans delete the membership row, so re-bans and unbans authorize
+      // against the stored former role: a re-ban must not let an Admin
+      // downgrade an ex-Admin's stored role to Member and then lift it.
+      const [existingBan] =
+        action.type === "member.ban" || action.type === "member.unban"
+          ? await db
+              .select({ role: s.communityBans.role })
+              .from(s.communityBans)
+              .where(
+                and(
+                  eq(s.communityBans.communityId, action.communityId),
+                  eq(s.communityBans.userId, action.userId),
+                ),
+              )
+              .limit(1)
+          : [];
       // Ban/unban follow the same hierarchy as remove: Admins may act on
       // non-Admins, only Owners may touch Admins. (There is no role to
       // promote to here, so the member.role Admin-promotion guard is enough.)
+      const effectiveRole = targetRole ?? existingBan?.role;
       if (
         action.userId === userId ||
-        targetRole === "Owner" ||
+        effectiveRole === "Owner" ||
         (ownRole !== "Owner" &&
-          (targetRole === "Admin" ||
+          (effectiveRole === "Admin" ||
             (action.type === "member.role" && action.role === "Admin")))
       )
         throw new HttpError(403, "You cannot change this member.");
       if (action.type === "member.unban") {
-        // The ban deleted the membership, so hierarchy comes from the stored
-        // former role: only Owners may unban ex-Admins (or ex-Owners, which
-        // cannot normally exist since Owners cannot be banned).
-        const [ban] = await db
-          .select({ role: s.communityBans.role })
-          .from(s.communityBans)
-          .where(
-            and(
-              eq(s.communityBans.communityId, action.communityId),
-              eq(s.communityBans.userId, action.userId),
-            ),
-          )
-          .limit(1);
-        if (
-          ban &&
-          (ban.role === "Admin" || ban.role === "Owner") &&
-          ownRole !== "Owner"
-        )
-          throw new HttpError(403, "You cannot change this member.");
         await db
           .delete(s.communityBans)
           .where(
@@ -322,14 +320,14 @@ export async function mutate(db: Database, userId: string, action: Action) {
           );
         break;
       }
-      if (action.type === "member.ban" && !targetRole) {
+      if (action.type === "member.ban" && !targetRole && !existingBan) {
         const [person] = await db
           .select({ id: s.user.id })
           .from(s.user)
           .where(eq(s.user.id, action.userId))
           .limit(1);
         if (!person) throw new HttpError(404, "Person not found.");
-      } else if (!targetRole) {
+      } else if (!targetRole && !existingBan) {
         throw new HttpError(403, "You cannot change this member.");
       }
       const where = and(
@@ -354,7 +352,8 @@ export async function mutate(db: Database, userId: string, action: Action) {
           insert into community_bans (community_id, user_id, banned_by, role, reason)
           values (
             ${action.communityId}, ${action.userId}, ${userId},
-            ${targetRole ?? "Member"}, ${action.reason ?? ""}
+            ${targetRole ?? existingBan?.role ?? "Member"},
+            ${action.reason ?? ""}
           )
           on conflict (community_id, user_id) do update set
             banned_by = excluded.banned_by, role = excluded.role,

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -117,6 +117,19 @@ export async function mutate(db: Database, userId: string, action: Action) {
         .where(eq(s.communities.id, action.id));
       break;
     case "community.join": {
+      // Single statement decides membership, so a concurrent ban cannot slip
+      // between the checks and the insert. Reads below only pick the message.
+      const written = await db.execute<{ communityId: string }>(sql`
+        insert into community_members (community_id, user_id)
+        select id, ${userId} from communities
+        where id = ${action.id} and discoverable
+          and not exists (
+            select 1 from community_bans
+            where community_id = ${action.id} and user_id = ${userId}
+          )
+        on conflict do nothing returning community_id as "communityId"
+      `);
+      if (written.rows.length) break;
       const [community] = await db
         .select()
         .from(s.communities)
@@ -134,16 +147,10 @@ export async function mutate(db: Database, userId: string, action: Action) {
         .limit(1);
       if (banned)
         throw new HttpError(403, "You cannot join this community.");
-      if (!community.discoverable)
-        throw new HttpError(
-          403,
-          "This community can only be joined with an invite.",
-        );
-      await db
-        .insert(s.members)
-        .values({ communityId: action.id, userId })
-        .onConflictDoNothing();
-      break;
+      throw new HttpError(
+        403,
+        "This community can only be joined with an invite.",
+      );
     }
     case "community.leave":
       if ((await roleFor(db, userId, action.id)) === "Owner")
@@ -256,14 +263,15 @@ export async function mutate(db: Database, userId: string, action: Action) {
     case "member.unban": {
       const ownRole = await requireManager(db, userId, action.communityId);
       const targetRole = await roleFor(db, action.userId, action.communityId);
+      // Ban/unban follow the same hierarchy as remove: Admins may act on
+      // non-Admins, only Owners may touch Admins. (There is no role to
+      // promote to here, so the member.role Admin-promotion guard is enough.)
       if (
         action.userId === userId ||
         targetRole === "Owner" ||
         (ownRole !== "Owner" &&
           (targetRole === "Admin" ||
-            (action.type === "member.role" && action.role === "Admin") ||
-            action.type === "member.ban" ||
-            action.type === "member.unban"))
+            (action.type === "member.role" && action.role === "Admin")))
       )
         throw new HttpError(403, "You cannot change this member.");
       if (action.type === "member.unban") {
@@ -291,38 +299,48 @@ export async function mutate(db: Database, userId: string, action: Action) {
         eq(s.members.communityId, action.communityId),
         eq(s.members.userId, action.userId),
       );
-      if (action.type === "member.role")
+      if (action.type === "member.role") {
         await db.update(s.members).set({ role: action.role }).where(where);
-      else {
-        await db.delete(s.members).where(where);
-        await db
-          .delete(s.participants)
-          .where(
-            and(
-              eq(s.participants.userId, action.userId),
-              inArray(
-                s.participants.conversationId,
-                db
-                  .select({ id: s.conversations.id })
-                  .from(s.conversations)
-                  .where(eq(s.conversations.communityId, action.communityId)),
-              ),
-            ),
-          );
-        if (action.type === "member.ban")
-          await db
-            .insert(s.communityBans)
-            .values({
-              communityId: action.communityId,
-              userId: action.userId,
-              bannedBy: userId,
-              reason: action.reason ?? "",
-            })
-            .onConflictDoUpdate({
-              target: [s.communityBans.communityId, s.communityBans.userId],
-              set: { bannedBy: userId, reason: action.reason ?? "" },
-            });
+        break;
       }
+      if (action.type === "member.ban") {
+        // One statement removes membership and records the ban, so a join
+        // racing this ban resolves correctly whichever statement runs first:
+        // either the join sees the ban and inserts nothing, or the ban
+        // deletes the freshly inserted membership.
+        await db.execute(sql`
+          with deleted as (
+            delete from community_members
+            where community_id = ${action.communityId}
+              and user_id = ${action.userId}
+          )
+          insert into community_bans (community_id, user_id, banned_by, reason)
+          values (
+            ${action.communityId}, ${action.userId}, ${userId},
+            ${action.reason ?? ""}
+          )
+          on conflict (community_id, user_id) do update set
+            banned_by = excluded.banned_by, reason = excluded.reason
+        `);
+      } else {
+        await db.delete(s.members).where(where);
+      }
+      // Stale private-channel rows are harmless: private access still requires
+      // community membership, which bans and removals both delete.
+      await db
+        .delete(s.participants)
+        .where(
+          and(
+            eq(s.participants.userId, action.userId),
+            inArray(
+              s.participants.conversationId,
+              db
+                .select({ id: s.conversations.id })
+                .from(s.conversations)
+                .where(eq(s.conversations.communityId, action.communityId)),
+            ),
+          ),
+        );
       break;
     }
     case "channel.access": {

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -147,6 +147,24 @@ export async function mutate(db: Database, userId: string, action: Action) {
         .limit(1);
       if (banned)
         throw new HttpError(403, "You cannot join this community.");
+      if (!community.discoverable)
+        throw new HttpError(
+          403,
+          "This community can only be joined with an invite.",
+        );
+      // The insert wrote nothing but the community is joinable: this is an
+      // idempotent retry by an existing member.
+      const [existing] = await db
+        .select({ userId: s.members.userId })
+        .from(s.members)
+        .where(
+          and(
+            eq(s.members.communityId, action.id),
+            eq(s.members.userId, userId),
+          ),
+        )
+        .limit(1);
+      if (existing) break;
       throw new HttpError(
         403,
         "This community can only be joined with an invite.",
@@ -275,6 +293,25 @@ export async function mutate(db: Database, userId: string, action: Action) {
       )
         throw new HttpError(403, "You cannot change this member.");
       if (action.type === "member.unban") {
+        // The ban deleted the membership, so hierarchy comes from the stored
+        // former role: only Owners may unban ex-Admins (or ex-Owners, which
+        // cannot normally exist since Owners cannot be banned).
+        const [ban] = await db
+          .select({ role: s.communityBans.role })
+          .from(s.communityBans)
+          .where(
+            and(
+              eq(s.communityBans.communityId, action.communityId),
+              eq(s.communityBans.userId, action.userId),
+            ),
+          )
+          .limit(1);
+        if (
+          ban &&
+          (ban.role === "Admin" || ban.role === "Owner") &&
+          ownRole !== "Owner"
+        )
+          throw new HttpError(403, "You cannot change this member.");
         await db
           .delete(s.communityBans)
           .where(
@@ -314,13 +351,14 @@ export async function mutate(db: Database, userId: string, action: Action) {
             where community_id = ${action.communityId}
               and user_id = ${action.userId}
           )
-          insert into community_bans (community_id, user_id, banned_by, reason)
+          insert into community_bans (community_id, user_id, banned_by, role, reason)
           values (
             ${action.communityId}, ${action.userId}, ${userId},
-            ${action.reason ?? ""}
+            ${targetRole ?? "Member"}, ${action.reason ?? ""}
           )
           on conflict (community_id, user_id) do update set
-            banned_by = excluded.banned_by, reason = excluded.reason
+            banned_by = excluded.banned_by, role = excluded.role,
+            reason = excluded.reason
         `);
       } else {
         await db.delete(s.members).where(where);

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -122,6 +122,18 @@ export async function mutate(db: Database, userId: string, action: Action) {
         .from(s.communities)
         .where(eq(s.communities.id, action.id));
       if (!community) throw new HttpError(404, "Community not found.");
+      const [banned] = await db
+        .select({ userId: s.communityBans.userId })
+        .from(s.communityBans)
+        .where(
+          and(
+            eq(s.communityBans.communityId, action.id),
+            eq(s.communityBans.userId, userId),
+          ),
+        )
+        .limit(1);
+      if (banned)
+        throw new HttpError(403, "You cannot join this community.");
       if (!community.discoverable)
         throw new HttpError(
           403,
@@ -239,18 +251,42 @@ export async function mutate(db: Database, userId: string, action: Action) {
       break;
     }
     case "member.role":
-    case "member.remove": {
+    case "member.remove":
+    case "member.ban":
+    case "member.unban": {
       const ownRole = await requireManager(db, userId, action.communityId);
       const targetRole = await roleFor(db, action.userId, action.communityId);
       if (
-        !targetRole ||
-        targetRole === "Owner" ||
         action.userId === userId ||
+        targetRole === "Owner" ||
         (ownRole !== "Owner" &&
           (targetRole === "Admin" ||
-            (action.type === "member.role" && action.role === "Admin")))
+            (action.type === "member.role" && action.role === "Admin") ||
+            action.type === "member.ban" ||
+            action.type === "member.unban"))
       )
         throw new HttpError(403, "You cannot change this member.");
+      if (action.type === "member.unban") {
+        await db
+          .delete(s.communityBans)
+          .where(
+            and(
+              eq(s.communityBans.communityId, action.communityId),
+              eq(s.communityBans.userId, action.userId),
+            ),
+          );
+        break;
+      }
+      if (action.type === "member.ban" && !targetRole) {
+        const [person] = await db
+          .select({ id: s.user.id })
+          .from(s.user)
+          .where(eq(s.user.id, action.userId))
+          .limit(1);
+        if (!person) throw new HttpError(404, "Person not found.");
+      } else if (!targetRole) {
+        throw new HttpError(403, "You cannot change this member.");
+      }
       const where = and(
         eq(s.members.communityId, action.communityId),
         eq(s.members.userId, action.userId),
@@ -273,6 +309,19 @@ export async function mutate(db: Database, userId: string, action: Action) {
               ),
             ),
           );
+        if (action.type === "member.ban")
+          await db
+            .insert(s.communityBans)
+            .values({
+              communityId: action.communityId,
+              userId: action.userId,
+              bannedBy: userId,
+              reason: action.reason ?? "",
+            })
+            .onConflictDoUpdate({
+              target: [s.communityBans.communityId, s.communityBans.userId],
+              set: { bannedBy: userId, reason: action.reason ?? "" },
+            });
       }
       break;
     }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -128,6 +128,26 @@ export const members = pgTable(
     index("membership_user_idx").on(t.userId),
   ],
 );
+export const communityBans = pgTable(
+  "community_bans",
+  {
+    communityId: text("community_id")
+      .notNull()
+      .references(() => communities.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    bannedBy: text("banned_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    reason: text("reason").notNull().default(""),
+    createdAt: time("created_at"),
+  },
+  (t) => [
+    primaryKey({ columns: [t.communityId, t.userId] }),
+    index("community_ban_user_idx").on(t.userId),
+  ],
+);
 export const communityInvites = pgTable(
   "community_invites",
   {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -140,6 +140,11 @@ export const communityBans = pgTable(
     bannedBy: text("banned_by").references(() => user.id, {
       onDelete: "set null",
     }),
+    // Former community role at ban time. Membership is deleted by the ban,
+    // so unban authorization reads this instead of the members table.
+    role: text("role", { enum: ["Owner", "Admin", "Moderator", "Member"] })
+      .notNull()
+      .default("Member"),
     reason: text("reason").notNull().default(""),
     createdAt: time("created_at"),
   },

--- a/src/server/fast-actions.ts
+++ b/src/server/fast-actions.ts
@@ -12,14 +12,18 @@ export async function fastAction(db: Database, userId: string, action: Action) {
     const result = await db.execute<{
       allowed: boolean;
       requests: number | null;
+      banned: boolean;
     }>(sql`
       with allowed as materialized (select id from communities where id = ${action.id} and discoverable),
+      banned as materialized (select 1 from community_bans where community_id = ${action.id} and user_id = ${userId}),
       quota as (${quota(userId)}),
-      written as (insert into community_members (community_id, user_id) select id, ${userId} from allowed, quota where quota.count <= 120 on conflict do nothing returning community_id),
+      written as (insert into community_members (community_id, user_id) select id, ${userId} from allowed, quota where quota.count <= 120 and not exists(select 1 from banned) on conflict do nothing returning community_id),
       notified as (insert into app_events (id, user_id) select gen_random_uuid()::text, id from
         (select user_id as id from community_members where community_id = ${action.id} union select ${userId}::text) recipients where exists(select 1 from written))
-      select exists(select 1 from allowed) as allowed, (select count from quota) as requests
+      select exists(select 1 from allowed) as allowed, (select count from quota) as requests, exists(select 1 from banned) as banned
     `);
+    if (result.rows[0].banned)
+      throw new HttpError(403, "You cannot join this community.");
     check(result.rows[0], "This community can only be joined with an invite.");
     return true;
   }

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -177,20 +177,9 @@ export async function acceptInvite(
   code: string,
 ): Promise<AcceptedInvite> {
   if (!validInviteCode(code)) throw new HttpError(404, "Invite not found.");
-  const [banned] = await db
-    .select({ communityId: s.communityBans.communityId })
-    .from(s.communityBans)
-    .innerJoin(
-      s.communityInvites,
-      and(
-        eq(s.communityInvites.code, code),
-        eq(s.communityInvites.communityId, s.communityBans.communityId),
-      ),
-    )
-    .where(eq(s.communityBans.userId, userId))
-    .limit(1);
-  if (banned)
-    throw new HttpError(404, "This invitation is no longer available.");
+  // The ban exclusion lives in the same statement as the membership insert,
+  // so a ban committing concurrently still blocks the join. Banned users see
+  // the same message as a revoked invite, leaking nothing about ban status.
   const result = await db.execute<{ communityId: string; channelId: string }>(sql`
     with invite as materialized (
       select * from community_invites where code = ${code}
@@ -201,6 +190,11 @@ export async function acceptInvite(
     ), joined as (
       insert into community_members (community_id, user_id)
       select community_id, ${userId} from invite
+      where not exists (
+        select 1 from community_bans
+        where community_bans.community_id = invite.community_id
+          and community_bans.user_id = ${userId}
+      )
       on conflict do nothing returning community_id
     ), counted as (
       update community_invites set use_count = use_count + 1
@@ -212,6 +206,15 @@ export async function acceptInvite(
         'general'
       ) as "channelId"
     from invite i
+    where exists (select 1 from joined)
+      or exists (
+        select 1 from community_members m
+        where m.community_id = i.community_id and m.user_id = ${userId}
+          and not exists (
+            select 1 from community_bans b
+            where b.community_id = m.community_id and b.user_id = ${userId}
+          )
+      )
   `);
   const accepted = result.rows[0];
   if (!accepted) throw new HttpError(404, "This invitation is no longer available.");

--- a/src/server/invites.ts
+++ b/src/server/invites.ts
@@ -177,6 +177,20 @@ export async function acceptInvite(
   code: string,
 ): Promise<AcceptedInvite> {
   if (!validInviteCode(code)) throw new HttpError(404, "Invite not found.");
+  const [banned] = await db
+    .select({ communityId: s.communityBans.communityId })
+    .from(s.communityBans)
+    .innerJoin(
+      s.communityInvites,
+      and(
+        eq(s.communityInvites.code, code),
+        eq(s.communityInvites.communityId, s.communityBans.communityId),
+      ),
+    )
+    .where(eq(s.communityBans.userId, userId))
+    .limit(1);
+  if (banned)
+    throw new HttpError(404, "This invitation is no longer available.");
   const result = await db.execute<{ communityId: string; channelId: string }>(sql`
     with invite as materialized (
       select * from community_invites where code = ${code}

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -157,7 +157,7 @@ export async function snapshot(
     related as materialized (
       select ${userId}::text as id
       union select user_id from community_members where community_id in (select community_id from joined)
-      union select user_id from community_bans where community_id in (select community_id from joined)
+      union select user_id from community_bans where community_id in (select community_id from community_members where user_id = ${userId} and role in ('Owner', 'Admin'))
       union select case when sender_id = ${userId} then recipient_id else sender_id end from friendships where sender_id = ${userId} or recipient_id = ${userId}
       union select case when user_id = ${userId} then target_id else user_id end from blocked_users where user_id = ${userId} or target_id = ${userId}
       union select user_id from conversation_members where conversation_id in (select id from permitted where kind = 'dm')
@@ -246,6 +246,11 @@ export async function snapshot(
     communities: communityRows.map((c) => {
       const membership = allMembers.filter((m) => m.communityId === c.id);
       const joined = membership.some((m) => m.userId === userId);
+      // Ban lists are manager-only: regular members must not learn who was
+      // banned. Managers see them via the Banned section in settings.
+      const viewerRole = membership.find((m) => m.userId === userId)?.role;
+      const canSeeBans =
+        joined && (viewerRole === "Owner" || viewerRole === "Admin");
       return {
         ...c,
         icon: c.icon as Community["icon"],
@@ -263,7 +268,7 @@ export async function snapshot(
               ]),
             )
           : {},
-        bannedIds: joined
+        bannedIds: canSeeBans
           ? banned
               .filter((b) => b.communityId === c.id)
               .map((b) => (b.userId === userId ? "you" : b.userId))

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -146,6 +146,7 @@ export async function snapshot(
       personId: string;
       hasMessages: boolean;
     }[];
+    banned: { communityId: string; userId: string }[];
     allowed: (typeof s.conversations.$inferSelect)[];
     messageRows: (typeof s.messages.$inferSelect)[];
     startedChannels: string[];
@@ -156,6 +157,7 @@ export async function snapshot(
     related as materialized (
       select ${userId}::text as id
       union select user_id from community_members where community_id in (select community_id from joined)
+      union select user_id from community_bans where community_id in (select community_id from joined)
       union select case when sender_id = ${userId} then recipient_id else sender_id end from friendships where sender_id = ${userId} or recipient_id = ${userId}
       union select case when user_id = ${userId} then target_id else user_id end from blocked_users where user_id = ${userId} or target_id = ${userId}
       union select user_id from conversation_members where conversation_id in (select id from permitted where kind = 'dm')
@@ -175,6 +177,7 @@ export async function snapshot(
       where ${s.profiles.userId} in (select id from related union select author_id from messages where id in (select id from history))), '[]') as "profileRows",
     coalesce((select jsonb_agg(${rowJson(s.communities)} || jsonb_build_object('iconUrl', (select '/api/community-icons/' || i.id from community_icons i where i.community_id = ${s.communities.id} and i.status = 'active'), 'memberCount', (select count(*)::int from community_members m where m.community_id = ${s.communities.id})) order by ${s.communities.createdAt}) from ${s.communities} where ${s.communities.id} in (select id from catalog)), '[]') as "communityRows",
     coalesce((select jsonb_agg(${rowJson(s.members)}) from ${s.members} where ${s.members.communityId} in (select community_id from joined)), '[]') as "allMembers",
+    coalesce((select jsonb_agg(jsonb_build_object('communityId', ${s.communityBans.communityId}, 'userId', ${s.communityBans.userId})) from ${s.communityBans} where ${s.communityBans.communityId} in (select community_id from joined)), '[]') as banned,
     coalesce((select jsonb_agg(${rowJson(s.categories)} order by ${s.categories.position}, ${s.categories.name}) from ${s.categories} where ${s.categories.communityId} in (select community_id from joined)), '[]') as "categoryRows",
     coalesce((select jsonb_agg(${rowJson(s.friendships)}) from ${s.friendships} where ${s.friendships.senderId} = ${userId} or ${s.friendships.recipientId} = ${userId}), '[]') as friendships,
     coalesce((select jsonb_agg(${rowJson(s.blocks)}) from ${s.blocks} where ${s.blocks.userId} = ${userId} or ${s.blocks.targetId} = ${userId}), '[]') as blocked,
@@ -197,6 +200,7 @@ export async function snapshot(
     profileRows,
     communityRows,
     allMembers,
+    banned,
     categoryRows,
     friendships,
     blocked,
@@ -259,6 +263,11 @@ export async function snapshot(
               ]),
             )
           : {},
+        bannedIds: joined
+          ? banned
+              .filter((b) => b.communityId === c.id)
+              .map((b) => (b.userId === userId ? "you" : b.userId))
+          : [],
         channelCategories: joined
           ? categoryRows
               .filter((g) => g.communityId === c.id)

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -42,6 +42,7 @@ export type Community = {
   members: number;
   memberIds?: string[];
   memberRoles?: Record<string, Person["role"]>;
+  bannedIds?: string[];
   joined: boolean;
   channels: Channel[];
   channelCategories?: string[];

--- a/tests/community-bans.test.ts
+++ b/tests/community-bans.test.ts
@@ -18,7 +18,7 @@ const communityId = "ban-corner";
 
 before(async () => {
   await migrate(database, { migrationsFolder: "./drizzle" });
-  for (const id of ["owner", "admin", "member", "outsider"]) {
+  for (const id of ["owner", "admin", "member", "watcher", "outsider"]) {
     await db
       .insert(schema.user)
       .values({ id, name: id, email: `${id}@bans.test` });
@@ -37,22 +37,15 @@ before(async () => {
     },
     channels: [{ id: "general", name: "general", description: "", group: "" }],
   });
+  await mutate(db, "admin", { type: "community.join", id: communityId });
   await mutate(db, "owner", {
     type: "member.role",
     communityId,
     userId: "admin",
     role: "Admin",
-  }).catch(async () => {
-    // admin must join before promotion
-    await mutate(db, "admin", { type: "community.join", id: communityId });
-    await mutate(db, "owner", {
-      type: "member.role",
-      communityId,
-      userId: "admin",
-      role: "Admin",
-    });
   });
   await mutate(db, "member", { type: "community.join", id: communityId });
+  await mutate(db, "watcher", { type: "community.join", id: communityId });
 });
 
 after(() => engine.close());
@@ -111,6 +104,19 @@ test("bans remove members and block rejoining, unbans restore it", async () => {
   assert.ok(bannedCommunity?.bannedIds?.includes("member"));
   assert.ok(!bannedCommunity?.memberIds?.includes("member"));
 
+  // Ban lists are manager-only: admins see them, plain members do not.
+  const adminSnap = await snapshot(db, { id: "admin", name: "admin" }, 0);
+  assert.ok(
+    adminSnap.communities
+      .find((c) => c.id === communityId)
+      ?.bannedIds?.includes("member"),
+  );
+  const watcherSnap = await snapshot(db, { id: "watcher", name: "watcher" }, 0);
+  assert.deepEqual(
+    watcherSnap.communities.find((c) => c.id === communityId)?.bannedIds,
+    [],
+  );
+
   // Banned user cannot rejoin directly (both paths) or via invite.
   await assert.rejects(
     () => mutate(db, "member", { type: "community.join", id: communityId }),
@@ -147,5 +153,37 @@ test("bans remove members and block rejoining, unbans restore it", async () => {
   const rejoined = await snapshot(db, { id: "member", name: "member" }, 0);
   assert.ok(
     rejoined.communities.some((c) => c.id === communityId && c.joined),
+  );
+
+  // Admins follow remove parity: they can ban/unban plain members but not
+  // other admins, and cannot touch the owner.
+  await mutate(db, "admin", {
+    type: "member.ban",
+    communityId,
+    userId: "member",
+  });
+  await assert.rejects(
+    () => mutate(db, "member", { type: "community.join", id: communityId }),
+    /cannot join this community/,
+  );
+  await assert.rejects(
+    () =>
+      mutate(db, "admin", {
+        type: "member.ban",
+        communityId,
+        userId: "owner",
+      }),
+    /cannot change this member/,
+  );
+  await mutate(db, "admin", {
+    type: "member.unban",
+    communityId,
+    userId: "member",
+  });
+  await mutate(db, "member", { type: "community.join", id: communityId });
+  assert.ok(
+    (await snapshot(db, { id: "member", name: "member" }, 0)).communities.some(
+      (c) => c.id === communityId && c.joined,
+    ),
   );
 });

--- a/tests/community-bans.test.ts
+++ b/tests/community-bans.test.ts
@@ -1,0 +1,151 @@
+import { after, before, test } from "node:test";
+import assert from "node:assert/strict";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import type { Database } from "../src/server/db";
+import * as schema from "../src/server/db/schema";
+import { ensureProfile } from "../src/server/access";
+import { mutate } from "../src/server/actions";
+import { fastAction } from "../src/server/fast-actions";
+import { acceptInvite, createInvite } from "../src/server/invites";
+import { snapshot } from "../src/server/queries";
+
+const engine = new PGlite();
+const database = drizzle(engine, { schema });
+const db = database as unknown as Database;
+const communityId = "ban-corner";
+
+before(async () => {
+  await migrate(database, { migrationsFolder: "./drizzle" });
+  for (const id of ["owner", "admin", "member", "outsider"]) {
+    await db
+      .insert(schema.user)
+      .values({ id, name: id, email: `${id}@bans.test` });
+    await ensureProfile(db, { id, name: id });
+  }
+  await mutate(db, "owner", {
+    type: "community.create",
+    id: communityId,
+    community: {
+      name: "Ban corner",
+      description: "Bans keep this place safe.",
+      icon: "sun",
+      color: "purple",
+      category: "Tests",
+      discoverable: true,
+    },
+    channels: [{ id: "general", name: "general", description: "", group: "" }],
+  });
+  await mutate(db, "owner", {
+    type: "member.role",
+    communityId,
+    userId: "admin",
+    role: "Admin",
+  }).catch(async () => {
+    // admin must join before promotion
+    await mutate(db, "admin", { type: "community.join", id: communityId });
+    await mutate(db, "owner", {
+      type: "member.role",
+      communityId,
+      userId: "admin",
+      role: "Admin",
+    });
+  });
+  await mutate(db, "member", { type: "community.join", id: communityId });
+});
+
+after(() => engine.close());
+
+test("bans remove members and block rejoining, unbans restore it", async () => {
+  // Non-managers cannot ban.
+  await assert.rejects(
+    () =>
+      mutate(db, "member", {
+        type: "member.ban",
+        communityId,
+        userId: "outsider",
+      }),
+    /owners and admins/,
+  );
+
+  // Cannot ban the owner, yourself, or (as admin) another admin.
+  await assert.rejects(
+    () =>
+      mutate(db, "admin", {
+        type: "member.ban",
+        communityId,
+        userId: "owner",
+      }),
+    /cannot change this member/,
+  );
+  await assert.rejects(
+    () =>
+      mutate(db, "owner", {
+        type: "member.ban",
+        communityId,
+        userId: "owner",
+      }),
+    /cannot change this member/,
+  );
+  await assert.rejects(
+    () =>
+      mutate(db, "admin", {
+        type: "member.ban",
+        communityId,
+        userId: "admin",
+      }),
+    /cannot change this member/,
+  );
+
+  // Owner bans a member: membership gone, ban visible in snapshot.
+  await mutate(db, "owner", {
+    type: "member.ban",
+    communityId,
+    userId: "member",
+  });
+  const bannedSnap = await snapshot(db, { id: "owner", name: "owner" }, 0);
+  const bannedCommunity = bannedSnap.communities.find(
+    (c) => c.id === communityId,
+  );
+  assert.ok(bannedCommunity?.bannedIds?.includes("member"));
+  assert.ok(!bannedCommunity?.memberIds?.includes("member"));
+
+  // Banned user cannot rejoin directly (both paths) or via invite.
+  await assert.rejects(
+    () => mutate(db, "member", { type: "community.join", id: communityId }),
+    /cannot join this community/,
+  );
+  await assert.rejects(
+    () => fastAction(db, "member", { type: "community.join", id: communityId }),
+    /cannot join this community/,
+  );
+  const invite = await createInvite(db, "owner", communityId);
+  await assert.rejects(
+    () => acceptInvite(db, "member", invite.code),
+    /no longer available/,
+  );
+
+  // Unban restores invite joins.
+  await mutate(db, "owner", {
+    type: "member.unban",
+    communityId,
+    userId: "member",
+  });
+  assert.deepEqual(await acceptInvite(db, "member", invite.code), {
+    communityId,
+    channelId: "general",
+  });
+
+  // Remove (not ban) still allows rejoining.
+  await mutate(db, "owner", {
+    type: "member.remove",
+    communityId,
+    userId: "member",
+  });
+  await mutate(db, "member", { type: "community.join", id: communityId });
+  const rejoined = await snapshot(db, { id: "member", name: "member" }, 0);
+  assert.ok(
+    rejoined.communities.some((c) => c.id === communityId && c.joined),
+  );
+});

--- a/tests/community-bans.test.ts
+++ b/tests/community-bans.test.ts
@@ -186,4 +186,35 @@ test("bans remove members and block rejoining, unbans restore it", async () => {
       (c) => c.id === communityId && c.joined,
     ),
   );
+
+  // Rejoining while already a member succeeds idempotently.
+  await mutate(db, "member", { type: "community.join", id: communityId });
+
+  // Bans remember the former role: an Admin cannot lift an Owner's ban of an
+  // Admin, but the Owner can.
+  await mutate(db, "owner", {
+    type: "member.role",
+    communityId,
+    userId: "member",
+    role: "Admin",
+  });
+  await mutate(db, "owner", {
+    type: "member.ban",
+    communityId,
+    userId: "member",
+  });
+  await assert.rejects(
+    () =>
+      mutate(db, "admin", {
+        type: "member.unban",
+        communityId,
+        userId: "member",
+      }),
+    /cannot change this member/,
+  );
+  await mutate(db, "owner", {
+    type: "member.unban",
+    communityId,
+    userId: "member",
+  });
 });

--- a/tests/community-bans.test.ts
+++ b/tests/community-bans.test.ts
@@ -217,4 +217,42 @@ test("bans remove members and block rejoining, unbans restore it", async () => {
     communityId,
     userId: "member",
   });
+
+  // Re-banning an ex-Admin cannot downgrade the stored role: an Admin's
+  // re-ban is rejected, so the ban stays Owner-only to lift.
+  await mutate(db, "member", { type: "community.join", id: communityId });
+  await mutate(db, "owner", {
+    type: "member.role",
+    communityId,
+    userId: "member",
+    role: "Admin",
+  });
+  await mutate(db, "owner", {
+    type: "member.ban",
+    communityId,
+    userId: "member",
+  });
+  await assert.rejects(
+    () =>
+      mutate(db, "admin", {
+        type: "member.ban",
+        communityId,
+        userId: "member",
+      }),
+    /cannot change this member/,
+  );
+  await assert.rejects(
+    () =>
+      mutate(db, "admin", {
+        type: "member.unban",
+        communityId,
+        userId: "member",
+      }),
+    /cannot change this member/,
+  );
+  await mutate(db, "owner", {
+    type: "member.unban",
+    communityId,
+    userId: "member",
+  });
 });


### PR DESCRIPTION
## Problem @xt42io 

Removing a member (`member.remove`) doesn't keep them out: public communities can be rejoined freely, and private ones re-entered with any still-valid invite link. There is no way to permanently exclude someone, which a community chat app needs for basic safety.

## Behavior

- New `member.ban` command (Owner/Admin only, same hierarchy rules as remove: can't touch Owners, Admins can't ban Admins). Banning removes membership plus private-channel access and records the ban with an optional reason. Works even if the person already left.
- New `member.unban` command lifts the ban without re-adding membership.
- Banned users are rejected from `community.join` (both the `mutate` and single-statement fast paths) and from `acceptInvite` (returns the same "no longer available" 404 as a revoked invite, so ban status isn't leaked).
- Community settings gains a Ban action per member (confirm dialog) and a Banned section listing banned members with Unban buttons. Snapshot exposes `bannedIds` per community in the existing query, no extra round-trip.

## Migration

`drizzle/0015_community_bans.sql` creates `community_bans`. Run `pnpm db:migrate` after pulling.

## Checks run

- New `tests/community-bans.test.ts`: permission rejections, ban removes + blocks join/fast-join/invite, unban restores invite join, plain remove still allows rejoin. Passes.
- `backend` (20), `performance` (12), `invites` + `community-discoverability` — all pass, including the snapshot query-count guards.
- `tsc --noEmit`: only the pre-existing `router.tsx` error, nothing in changed files.
- Full suite: 102/103; the single failure is `request-abort.test.ts`, which also fails on the clean tree in this environment (Windows).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds community bans so Owners and Admins can permanently exclude members, closing the rejoin loophole where removed members could re-enter public communities or use a still-valid invite for private ones.

**New Features**
- Adds `member.ban` and `member.unban` with the same hierarchy as `member.remove`: Admins can act on non-Admins, only Owners can touch Admins; banning removes membership and private-channel access even if the person already left.
- Ban checks run inside the join and invite membership statements, so a concurrent ban can't slip between check and insert; banned users get a 403 on direct join and the same 404 as a revoked invite on `acceptInvite`.
- Community settings gains a Ban action per member and a Banned section with Unban buttons; `bannedIds` is exposed to Owners and Admins only.
- Existing members rejoining a discoverable community still succeed idempotently.
- Bans store the member's former role; re-ban and unban authorize against it, so Admins can't re-ban an ex-Admin to downgrade the stored role and then lift it.

**Migration**
- Run `pnpm db:migrate` after pulling; the migrations create `community_bans` and add the former-role column, backfilling existing bans as Admin so they stay Owner-only to lift.

<sup>Written for commit 2587feae72854904a509beff58140ed2b67101db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/drocsid/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community owners and administrators can ban and unban members, with optional reasons.
  * Banned members appear in community settings, including unavailable profiles.
  * Banned users cannot rejoin communities or accept invitations.
  * Only community owners and administrators can view banned-member details.
  * Unbanning restores the member’s previous community role.
  * Removing a member without banning them still allows them to rejoin.

* **Tests**
  * Added coverage for ban permissions, visibility, rejoining restrictions, role restoration, unbanning, and member removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->